### PR TITLE
Use commonjs package type for JS client

### DIFF
--- a/clients/js/.eslintrc.cjs
+++ b/clients/js/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['@solana/eslint-config-solana'],
-  ignorePatterns: ['.eslintrc.cjs'],
+  ignorePatterns: ['.eslintrc.cjs', 'tsup.config.ts', 'env-shim.ts'],
   parserOptions: {
     project: 'tsconfig.json',
     tsconfigRootDir: __dirname,

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@solana-program/system",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "JavaScript client for the System program",
   "sideEffects": false,
-  "module": "./dist/src/index.js",
-  "main": "./dist/src/index.cjs",
-  "types": "./dist/types/src/index.d.ts",
-  "type": "module",
+  "module": "./dist/src/index.mjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/types/index.d.ts",
+  "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/types/src/index.d.ts",
-      "import": "./dist/src/index.js",
-      "require": "./dist/src/index.cjs"
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/src/index.mjs",
+      "require": "./dist/src/index.js"
     }
   },
   "files": [

--- a/clients/js/test/_setup.ts
+++ b/clients/js/test/_setup.ts
@@ -27,7 +27,7 @@ import {
   getCreateAccountInstruction,
   getInitializeNonceAccountInstruction,
   getNonceSize,
-} from '../src/index.js';
+} from '../src';
 
 type Client = {
   rpc: Rpc<SolanaRpcApi>;

--- a/clients/js/test/advanceNonceAccount.test.ts
+++ b/clients/js/test/advanceNonceAccount.test.ts
@@ -4,14 +4,14 @@ import {
   pipe,
 } from '@solana/web3.js';
 import test from 'ava';
-import { fetchNonce, getAdvanceNonceAccountInstruction } from '../src/index.js';
+import { fetchNonce, getAdvanceNonceAccountInstruction } from '../src';
 import {
   createDefaultSolanaClient,
   createDefaultTransaction,
   createNonceAccount,
   generateKeyPairSignerWithSol,
   signAndSendTransaction,
-} from './_setup.js';
+} from './_setup';
 
 test('it advances the nonce account', async (t) => {
   // Given an existing nonce account.

--- a/clients/js/test/createAccount.test.ts
+++ b/clients/js/test/createAccount.test.ts
@@ -5,16 +5,13 @@ import {
   pipe,
 } from '@solana/web3.js';
 import test from 'ava';
-import {
-  SYSTEM_PROGRAM_ADDRESS,
-  getCreateAccountInstruction,
-} from '../src/index.js';
+import { SYSTEM_PROGRAM_ADDRESS, getCreateAccountInstruction } from '../src';
 import {
   createDefaultSolanaClient,
   createDefaultTransaction,
   generateKeyPairSignerWithSol,
   signAndSendTransaction,
-} from './_setup.js';
+} from './_setup';
 
 test('it creates a new empty account', async (t) => {
   // Given we have a newly generated account keypair to create with 42 bytes of space.

--- a/clients/js/test/initializeNonceAccount.test.ts
+++ b/clients/js/test/initializeNonceAccount.test.ts
@@ -14,13 +14,13 @@ import {
   getCreateAccountInstruction,
   getInitializeNonceAccountInstruction,
   getNonceSize,
-} from '../src/index.js';
+} from '../src';
 import {
   createDefaultSolanaClient,
   createDefaultTransaction,
   generateKeyPairSignerWithSol,
   signAndSendTransaction,
-} from './_setup.js';
+} from './_setup';
 
 test('it creates and initialize a durable nonce account', async (t) => {
   // Given some brand now payer, authority, and nonce KeyPairSigners.

--- a/clients/js/test/transferSol.test.ts
+++ b/clients/js/test/transferSol.test.ts
@@ -7,17 +7,14 @@ import {
   pipe,
 } from '@solana/web3.js';
 import test from 'ava';
-import {
-  getTransferSolInstruction,
-  parseTransferSolInstruction,
-} from '../src/index.js';
+import { getTransferSolInstruction, parseTransferSolInstruction } from '../src';
 import {
   createDefaultSolanaClient,
   createDefaultTransaction,
   generateKeyPairSignerWithSol,
   getBalance,
   signAndSendTransaction,
-} from './_setup.js';
+} from './_setup';
 
 test('it transfers SOL from one account to another', async (t) => {
   // Given a source account with 3 SOL and a destination account with no SOL.

--- a/clients/js/tsconfig.declarations.json
+++ b/clients/js/tsconfig.declarations.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
-      "declaration": true,
-      "declarationMap": true,
-      "emitDeclarationOnly": true,
-      "outDir": "./dist/types",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types"
   },
-  "extends": "./tsconfig.json"
+  "extends": "./tsconfig.json",
+  "include": ["src"]
 }

--- a/clients/js/tsup.config.ts
+++ b/clients/js/tsup.config.ts
@@ -7,7 +7,7 @@ const SHARED_OPTIONS: Options = {
   entry: ['./src/index.ts'],
   inject: [path.resolve(__dirname, 'env-shim.ts')],
   outDir: './dist/src',
-  outExtension: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.js' }),
+  outExtension: ({ format }) => ({ js: format === 'cjs' ? '.js' : '.mjs' }),
   sourcemap: true,
   treeshake: true,
 };
@@ -22,7 +22,7 @@ export default defineConfig(() => [
     ...SHARED_OPTIONS,
     bundle: false,
     entry: ['./test/*.ts'],
-    format: 'esm',
+    format: 'cjs',
     outDir: './dist/test',
   },
 ]);


### PR DESCRIPTION
After many hours of research, this appears to be the most versatile and interoperable way of publishing dual package libraries.