### PR TITLE
Add kaigan serde feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6dd100976df9dd59d0c3fecf6f9ad3f161a087374d1b2a77ebb4ad8920f11bb"
 dependencies = [
  "borsh 0.10.3",
+ "serde",
 ]
 
 [[package]]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "../../LICENSE"
 [features]
 anchor = ["dep:anchor-lang"]
 test-sbf = []
-serde = ["dep:serde", "dep:serde_with"]
+serde = ["dep:serde", "dep:serde_with", "kaigan/serde"]
 
 [dependencies]
 anchor-lang = { version = "0.30.0", optional = true }


### PR DESCRIPTION
This PR adds the missing serde configuration for the `kaigan` crate.