### PR TITLE
interface: Add crate details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-interface"
-version = "0.0.1"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "borsh 1.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 resolver = "2"
 members = ["clients/rust", "interface"]
 
+[workspace.package]
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
+repository = "https://github.com/solana-program/system"
+homepage = "https://anza.xyz/"
+license = "Apache-2.0"
+edition = "2021"
+
 [workspace.metadata.cli]
 solana = "2.1.0"
 

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-system-interface"
-version = "0.0.1"
+version = "1.0.0"
 description = "Instructions and constructors for the System program"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/system"

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -2,10 +2,12 @@
 name = "solana-system-interface"
 version = "0.0.1"
 description = "Instructions and constructors for the System program"
+authors = ["Anza Maintainers <maintainers@anza.xyz>"]
 repository = "https://github.com/solana-program/system"
+homepage = "https://anza.xyz/"
+license = "Apache-2.0"
 edition = "2021"
 readme = "README.md"
-license-file = "../LICENSE"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -2,12 +2,12 @@
 name = "solana-system-interface"
 version = "1.0.0"
 description = "Instructions and constructors for the System program"
-authors = ["Anza Maintainers <maintainers@anza.xyz>"]
-repository = "https://github.com/solana-program/system"
-homepage = "https://anza.xyz/"
-license = "Apache-2.0"
-edition = "2021"
 readme = "README.md"
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]

--- a/interface/README.md
+++ b/interface/README.md
@@ -78,19 +78,19 @@ use anyhow::Result;
 fn transfer(
     client: &RpcClient,
     from: &Keypair,
-    recipient: &Keypair,
+    recipient: &Pubkey,
     lamports: u64,
 ) -> Result<()> {
     let instr = instruction::transfer(
         &from.pubkey(),
-        &recipient.pubkey(),
+        recipient,
         lamports,
     );
 
     let blockhash = client.get_latest_blockhash()?;
     let tx = Transaction::new_signed_with_payer(
         &[instr],
-        Some(&payer.pubkey()),
+        Some(&from.pubkey()),
         &[from],
         blockhash,
     );

--- a/interface/README.md
+++ b/interface/README.md
@@ -1,10 +1,10 @@
 <p align="center">
   <a href="https://solana.com">
-    <img alt="Solana" src="https://i.imgur.com/IKyzQ6T.png" width="250" />
+    <img alt="Solana" src="https://github.com/user-attachments/assets/534af75d-6347-48dc-8943-129423b2ba63" height="80" />
   </a>
 </p>
 
-# `solana-system-interface`
+# Solana System Interface
 
 This crate contains instructions and constructors for interacting with the [System program](https://docs.solanalabs.com/runtime/programs#system-program).
 

--- a/interface/README.md
+++ b/interface/README.md
@@ -1,3 +1,104 @@
+<p align="center">
+  <a href="https://solana.com">
+    <img alt="Solana" src="https://i.imgur.com/IKyzQ6T.png" width="250" />
+  </a>
+</p>
+
 # `solana-system-interface`
 
-Instructions and constructors for the System program.
+This crate contains instructions and constructors for interacting with the [System program](https://docs.solanalabs.com/runtime/programs#system-program).
+
+The System program can be used to create new accounts, allocate account data, assign accounts to owning programs, transfer lamports from System Program owned accounts and pay transaction fees.
+
+## Getting Started
+
+From your project folder:
+
+```bash
+cargo add solana-system-interface --features bincode
+```
+
+This will add the `solana-system-interface` dependency with the `bincode` feature enabled to your `Cargo.toml` file. The `bincode` feature contains the instruction constructors to create instructions for the System program.
+
+## Examples
+
+Creating an account:
+
+```rust
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use solana_system_interface::{instruction};
+use anyhow::Result;
+
+fn create_account(
+    client: &RpcClient,
+    payer: &Keypair,
+    new_account: &Keypair,
+    owning_program: &Pubkey,
+    space: u64,
+) -> Result<()> {
+    let rent = client.get_minimum_balance_for_rent_exemption(space.try_into()?)?;
+    let instr = instruction::create_account(
+        &payer.pubkey(),
+        &new_account.pubkey(),
+        rent,
+        space,
+        owning_program,
+    );
+
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[instr],
+        Some(&payer.pubkey()),
+        &[payer, new_account],
+        blockhash,
+    );
+
+    let _sig = client.send_and_confirm_transaction(&tx)?;
+
+    Ok(())
+}
+```
+
+Transfer lamports betweem accounts:
+
+```rust
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_pubkey::Pubkey;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use solana_system_interface::instruction;
+use anyhow::Result;
+
+fn transfer(
+    client: &RpcClient,
+    from: &Keypair,
+    recipient: &Keypair,
+    lamports: u64,
+) -> Result<()> {
+    let instr = instruction::transfer(
+        &from.pubkey(),
+        &recipient.pubkey(),
+        lamports,
+    );
+
+    let blockhash = client.get_latest_blockhash()?;
+    let tx = Transaction::new_signed_with_payer(
+        &[instr],
+        Some(&payer.pubkey()),
+        &[from],
+        blockhash,
+    );
+
+    let _sig = client.send_and_confirm_transaction(&tx)?;
+
+    Ok(())
+}
+```
+
+More examples can be found on the crate [documentation](https://docs.rs/solana-system-interface/latest/solana-system-interface/).

--- a/interface/README.md
+++ b/interface/README.md
@@ -30,7 +30,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
-use solana_system_interface::{instruction};
+use solana_system_interface::instruction;
 use anyhow::Result;
 
 fn create_account(


### PR DESCRIPTION
### Problem

The current `README.md` file for the interface crate does not contain relevant information.

### Solution

Add details about the interface crate, including how to install it and examples.