### PR TITLE
interface: Add WASM build to CI and fix it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,28 @@ jobs:
       - name: Lint / Docs
         run: pnpm zx ./scripts/interface/lint-docs.mjs
 
+  wasm_interface:
+    name: Build Interface in WASM
+    runs-on: ubuntu-latest
+    needs: format_and_lint_interface
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          cargo-cache-key: cargo-wasm-interface
+          solana: true
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build Interface with wasm-pack
+        run: pnpm interface:wasm
+
   test_interface:
     name: Test Interface
     runs-on: ubuntu-latest

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -54,3 +54,6 @@ frozen-abi = [
     "solana-pubkey/std"
 ]
 serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "interface:format": "zx ./scripts/interface/format.mjs",
     "interface:lint": "zx ./scripts/interface/lint.mjs",
     "interface:test": "zx ./scripts/interface/test.mjs",
+    "interface:wasm": "zx ./scripts/interface/wasm.mjs",
     "template:upgrade": "zx ./scripts/upgrade-template.mjs"
   },
   "devDependencies": {

--- a/scripts/interface/wasm.mjs
+++ b/scripts/interface/wasm.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import {
+  cliArguments,
+  workingDirectory,
+} from '../utils.mjs';
+
+// Configure additional arguments here, e.g.:
+// ['--arg1', '--arg2', ...cliArguments()]
+const buildArgs = cliArguments();
+const cratePath = path.join(workingDirectory, 'interface');
+
+// Build the interface.
+await $`wasm-pack build --target nodejs --dev ${cratePath} --features bincode ${buildArgs}`;


### PR DESCRIPTION
#### Problem

The solana-system-interface crate is meant to work with WASM, but it's not currently tested in CI.

#### Summary of changes

* Add `crate-type` to Cargo.toml, which is required for wasm-pack
* Add step testing `wasm-pack` in CI