### PR TITLE
Merge partition arguments helper

### DIFF
--- a/scripts/helpers/utils.mts
+++ b/scripts/helpers/utils.mts
@@ -111,22 +111,18 @@ export function popArgument(args: string[], arg: string) {
 
 export function partitionArguments(
   args: string[],
-  delimiter: string
+  delimiter: string,
+  defaultArgs?: string[]
 ): [string[], string[]] {
   const index = args.indexOf(delimiter);
-  return index >= 0
-    ? [args.slice(0, index), args.slice(index + 1)]
-    : [args, []];
-}
+  const [providedCargoArgs, providedCommandArgs] =
+    index >= 0 ? [args.slice(0, index), args.slice(index + 1)] : [args, []];
 
-export function partitionArgumentsWithDefaultArgs(
-  args: string[],
-  delimiter: string,
-  defaultArgs?: string[],
-): [string[], string[]] {
-  const [providedCargoArgs, providedCommandArgs] = partitionArguments(args, delimiter);
   if (defaultArgs) {
-    const [defaultCargoArgs, defaultCommandArgs] = partitionArguments(defaultArgs, delimiter);
+    const [defaultCargoArgs, defaultCommandArgs] = partitionArguments(
+      defaultArgs,
+      delimiter
+    );
     return [
       [...defaultCargoArgs, ...providedCargoArgs],
       [...defaultCommandArgs, ...providedCommandArgs],
@@ -144,10 +140,14 @@ export async function getInstalledSolanaVersion(): Promise<string | undefined> {
   }
 }
 
-export function parseCliArguments(): { command: string, libraryPath: string; args: string[] } {
+export function parseCliArguments(): {
+  command: string;
+  libraryPath: string;
+  args: string[];
+} {
   const command = process.argv[2];
   const args = process.argv.slice(3);
-  
+
   // Extract the relative crate directory from the command-line arguments. This
   // is the only required argument.
   const relativePath = args.shift();

--- a/scripts/js.mts
+++ b/scripts/js.mts
@@ -5,7 +5,7 @@
 import 'zx/globals';
 import {
     parseCliArguments,
-    partitionArgumentsWithDefaultArgs,
+    partitionArguments,
 } from './helpers/utils.mts';
 
 enum Command {
@@ -21,7 +21,7 @@ async function pnpm(
     command: string,
     build = false,
 ) {
-    const [pnpmArgs, commandArgs] = partitionArgumentsWithDefaultArgs(args, '--');
+    const [pnpmArgs, commandArgs] = partitionArguments(args, '--');
     cd(libraryPath);
     await $`pnpm install`;
     if (build) {

--- a/scripts/rust.mts
+++ b/scripts/rust.mts
@@ -7,7 +7,7 @@ import {
     getCargo,
     getToolchainArgument,
     parseCliArguments,
-    partitionArgumentsWithDefaultArgs,
+    partitionArguments,
     popArgument,
     workingDirectory,
 } from './helpers/utils.mts';
@@ -32,7 +32,7 @@ async function cargo(
     defaultArgs?: string[],
     variables?: [string, string][],
 ) {
-    const [cargoArgs, commandArgs] = partitionArgumentsWithDefaultArgs(args, '--', defaultArgs);
+    const [cargoArgs, commandArgs] = partitionArguments(args, '--', defaultArgs);
     variables?.forEach(([k, v]) => $.env[k] = v);
     await $`cargo ${toolchain} ${command} --manifest-path ${manifestPath} ${cargoArgs} -- ${commandArgs}`;
 }


### PR DESCRIPTION
### Problem

#32 introduced the `partitionArgumentsWithDefaultArgs` helper, which takes an optional `defaultArgs` parameter. Since the parameter is optional, it behaves the same way as the `partitionArguments` when it is not provided.

### Improvement

Merge both `partitionArguments` and `partitionArgumentsWithDefaultArgs` helpers, since they behaviour is similar.