### PR TITLE
processor: allocate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2000,6 +2000,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-poseidon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
+dependencies = [
+ "ark-bn254",
+ "ark-ff",
+ "num-bigint 0.4.6",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2109,45 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mollusk-svm"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e7c0b51a00d234774b61bf829aa75316eb3a5ebf30bd622010bd046daa287a"
+dependencies = [
+ "bincode",
+ "mollusk-svm-error",
+ "mollusk-svm-keys",
+ "solana-bpf-loader-program",
+ "solana-compute-budget",
+ "solana-log-collector",
+ "solana-logger",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-system-program 2.1.12",
+ "solana-timings",
+]
+
+[[package]]
+name = "mollusk-svm-error"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d7892725c98a376b55e03ccbea44a0d2111c8f7bab0432b42ea689f3f612e7"
+dependencies = [
+ "solana-sdk",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mollusk-svm-keys"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd18816096707d148467889844ae57384ab4cbbe50ed24fd03139e6e34d61301"
+dependencies = [
+ "mollusk-svm-error",
+ "solana-sdk",
 ]
 
 [[package]]
@@ -3353,6 +3404,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-loader-program"
+version = "2.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a72f4ec4df7ac88310560ec9e03358017176d38d6947f0de118925b31bfcc57c"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "libsecp256k1",
+ "log",
+ "scopeguard",
+ "solana-bn254",
+ "solana-compute-budget",
+ "solana-curve25519",
+ "solana-feature-set",
+ "solana-log-collector",
+ "solana-measure",
+ "solana-poseidon",
+ "solana-program-memory",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-timings",
+ "solana-type-overrides",
+ "solana_rbpf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "solana-client"
 version = "2.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,6 +3835,18 @@ dependencies = [
  "solana-sdk",
  "solana-short-vec",
  "solana-vote-program",
+]
+
+[[package]]
+name = "solana-poseidon"
+version = "2.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cb8f71202f04231fbc0869c94da00e7198abc9117100c62e4efb3cdf533f39d"
+dependencies = [
+ "ark-bn254",
+ "light-poseidon",
+ "solana-define-syscall",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4378,9 +4468,29 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
+version = "2.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e1e57bab6f597a95790ce6a1133a8984dd5e4939bffe87ac08b7b0fa1f545f"
+dependencies = [
+ "bincode",
+ "log",
+ "serde",
+ "serde_derive",
+ "solana-log-collector",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-type-overrides",
+]
+
+[[package]]
+name = "solana-system-program"
 version = "3.0.0"
 dependencies = [
+ "mollusk-svm",
+ "solana-account",
  "solana-account-info",
+ "solana-bincode",
+ "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-pubkey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ license = "Apache-2.0"
 edition = "2021"
 
 [workspace.dependencies]
+solana-account = "2.1"
 solana-account-info = "2.1"
+solana-bincode = "2.1"
 solana-cpi = "2.1"
 solana-decode-error = "2.1"
 solana-frozen-abi = "2.1"

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -2,7 +2,7 @@ use {
     num_traits::{FromPrimitive, ToPrimitive},
     solana_decode_error::DecodeError,
     solana_msg::msg,
-    solana_program_error::PrintProgramError,
+    solana_program_error::{PrintProgramError, ProgramError},
 };
 
 // Use strum when testing to ensure our FromPrimitive
@@ -125,6 +125,12 @@ impl core::fmt::Display for SystemError {
 impl PrintProgramError for SystemError {
     fn print<E>(&self) {
         msg!(&self.to_string());
+    }
+}
+
+impl From<SystemError> for ProgramError {
+    fn from(e: SystemError) -> Self {
+        Self::Custom(e as u32)
     }
 }
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -17,12 +17,17 @@ bpf-entrypoint = []
 
 [dependencies]
 solana-account-info = { workspace = true }
+solana-bincode = { workspace = true }
+solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
-solana-pubkey = { workspace = true }
-solana-system-interface = { path = "../interface" }
+solana-pubkey = { workspace = true, features = ["sha2"] }
+solana-system-interface = { path = "../interface", features = ["serde"] }
 
 [dev-dependencies]
+mollusk-svm = "0.0.15"
+solana-account = { workspace = true }
+solana-system-interface = { path = "../interface", features = ["bincode"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -1,9 +1,139 @@
 //! Program processor.
 
 use {
-    solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
+    solana_account_info::AccountInfo,
+    solana_msg::msg,
+    solana_program_error::{ProgramError, ProgramResult},
+    solana_pubkey::Pubkey,
+    solana_system_interface::{
+        error::SystemError, instruction::SystemInstruction, MAX_PERMITTED_DATA_LENGTH,
+    },
+    std::collections::HashSet,
 };
 
-pub fn process(_program_id: &Pubkey, _accounts: &[AccountInfo], _input: &[u8]) -> ProgramResult {
+// Maximum input buffer length that can be deserialized.
+// https://github.com/anza-xyz/solana-sdk/blob/41c663a8ec7269aa1117a2e3b0e24ff9ee1ac4af/packet/src/lib.rs#L32
+const MAX_INPUT_LEN: u64 = 1232;
+
+macro_rules! accounts {
+    ( $infos:ident, $signers:ident, $( $i:literal => $name:ident ),* $(,)? ) => {
+        let mut $signers = HashSet::new();
+        $(
+            let $name = $infos.get($i).ok_or(ProgramError::NotEnoughAccountKeys)?;
+            if $name.is_signer {
+                $signers.insert(*$name.key);
+            }
+        )*
+    };
+}
+
+// Represents an address that may or may not have been generated from a seed.
+#[derive(Debug)]
+struct Address {
+    address: Pubkey,
+    base: Option<Pubkey>,
+}
+
+impl Address {
+    fn is_signer(&self, signers: &HashSet<Pubkey>) -> bool {
+        if let Some(base) = self.base {
+            signers.contains(&base)
+        } else {
+            signers.contains(&self.address)
+        }
+    }
+
+    fn create(
+        address: &Pubkey,
+        with_seed: Option<(&Pubkey, &str, &Pubkey)>,
+    ) -> Result<Self, ProgramError> {
+        let base = if let Some((base, seed, owner)) = with_seed {
+            // Re-derive the address. It must match the supplied address.
+            let address_with_seed = Pubkey::create_with_seed(base, seed, owner)?;
+            if *address != address_with_seed {
+                msg!(
+                    "Create: address {} does not match derived address {}",
+                    address,
+                    address_with_seed
+                );
+                Err(SystemError::AddressWithSeedMismatch)?
+            }
+            Some(*base)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            address: *address,
+            base,
+        })
+    }
+}
+
+fn allocate(
+    info: &AccountInfo,
+    address: &Address,
+    space: u64,
+    signers: &HashSet<Pubkey>,
+) -> Result<(), ProgramError> {
+    if !address.is_signer(signers) {
+        msg!("Allocate: 'to' account {:?} must sign", address);
+        Err(ProgramError::MissingRequiredSignature)?
+    }
+
+    // If it looks like the account is already in use, bail.
+    if !info.data_is_empty() || !solana_system_interface::program::check_id(info.owner) {
+        msg!("Allocate: account {:?} already in use", address);
+        Err(SystemError::AccountAlreadyInUse)?
+    }
+
+    if space > MAX_PERMITTED_DATA_LENGTH {
+        msg!(
+            "Allocate: requested {}, max allowed {}",
+            space,
+            MAX_PERMITTED_DATA_LENGTH
+        );
+        Err(SystemError::InvalidAccountDataLength)?
+    }
+
+    /*
+    [TODO: CORE_BPF]:
+
+    This is going to behave differently than the builtin program right now,
+    since reallocations are limited to `MAX_PERMITTED_DATA_INCREASE``, which is
+    smaller than `MAX_PERMITTED_DATA_LENGTH`.
+
+    * `MAX_PERMITTED_DATA_LENGTH`   : 1_024 * 10 * 1_024
+    * `MAX_PERMITTED_DATA_INCREASE` : 1_024 * 10
+
+    https://github.com/solana-program/system/issues/30
+     */
+    info.realloc(space as usize, true)?;
+
     Ok(())
+}
+
+fn process_allocate(accounts: &[AccountInfo], space: u64) -> ProgramResult {
+    accounts!(
+        accounts,
+        signers,
+        0 => account_info,
+    );
+
+    let address = Address::create(account_info.key, None)?;
+
+    allocate(account_info, &address, space, &signers)
+}
+
+pub fn process(_program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
+    match solana_bincode::limited_deserialize::<SystemInstruction>(input, MAX_INPUT_LEN)
+        .map_err(|_| ProgramError::InvalidInstructionData)?
+    {
+        SystemInstruction::Allocate { space } => {
+            msg!("Instruction: Allocate");
+            process_allocate(accounts, space)
+        }
+        /* TODO: Remaining instruction implementations... */
+        _ => Err(ProgramError::InvalidInstructionData),
+    }
 }

--- a/program/tests/allocate.rs
+++ b/program/tests/allocate.rs
@@ -1,0 +1,112 @@
+mod setup;
+
+use {
+    mollusk_svm::result::Check,
+    solana_account::Account,
+    solana_account_info::MAX_PERMITTED_DATA_INCREASE,
+    solana_program_error::ProgramError,
+    solana_pubkey::Pubkey,
+    solana_system_interface::{
+        error::SystemError, instruction::allocate, MAX_PERMITTED_DATA_LENGTH,
+    },
+};
+
+const SPACE: u64 = 10_000;
+
+#[test]
+fn fail_account_not_signer() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    let mut instruction = allocate(&pubkey, SPACE);
+    instruction.accounts[0].is_signer = false;
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[(pubkey, Account::default())],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+#[test]
+fn fail_account_already_in_use() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    let account = Account {
+        data: vec![4; 32], // Has data
+        ..Account::default()
+    };
+
+    mollusk.process_and_validate_instruction(
+        &allocate(&pubkey, SPACE),
+        &[(pubkey, account)],
+        &[Check::err(ProgramError::Custom(
+            SystemError::AccountAlreadyInUse as u32,
+        ))],
+    );
+
+    let account = Account {
+        owner: Pubkey::new_unique(), // Not System
+        ..Account::default()
+    };
+
+    mollusk.process_and_validate_instruction(
+        &allocate(&pubkey, SPACE),
+        &[(pubkey, account)],
+        &[Check::err(ProgramError::Custom(
+            SystemError::AccountAlreadyInUse as u32,
+        ))],
+    );
+}
+
+#[test]
+fn fail_space_too_large() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    let space_too_large = MAX_PERMITTED_DATA_LENGTH + 1;
+
+    mollusk.process_and_validate_instruction(
+        &allocate(&pubkey, space_too_large),
+        &[(pubkey, Account::default())],
+        &[Check::err(ProgramError::Custom(
+            SystemError::InvalidAccountDataLength as u32,
+        ))],
+    );
+}
+
+// [TODO: CORE_BPF]: This verifies the concern for the `realloc` issue.
+#[test]
+fn fail_space_too_large_for_realloc() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    let space_too_large_for_realloc = MAX_PERMITTED_DATA_INCREASE + 1;
+
+    mollusk.process_and_validate_instruction(
+        &allocate(&pubkey, space_too_large_for_realloc as u64),
+        &[(pubkey, Account::default())],
+        &[Check::err(ProgramError::InvalidRealloc)], // See...?
+    );
+}
+
+#[test]
+fn success() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    mollusk.process_and_validate_instruction(
+        &allocate(&pubkey, SPACE),
+        &[(pubkey, Account::default())],
+        &[
+            Check::success(),
+            Check::account(&pubkey).space(SPACE as usize).build(),
+        ],
+    );
+}

--- a/program/tests/setup.rs
+++ b/program/tests/setup.rs
@@ -1,0 +1,8 @@
+use mollusk_svm::Mollusk;
+
+pub fn setup() -> Mollusk {
+    Mollusk::new(
+        &solana_system_interface::program::id(),
+        "solana_system_program",
+    )
+}


### PR DESCRIPTION
This PR implements the `Allocate` instruction processor in the BPF version of the System builtin program.

See #38 for a draft overview of the implemented base processor (no nonce instructions).