### PR TITLE
processor: assign

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -170,6 +170,17 @@ fn process_allocate_with_seed(
     assign(account_info, &address, &owner)
 }
 
+fn process_assign(accounts: &[AccountInfo], owner: Pubkey) -> ProgramResult {
+    accounts!(
+        accounts,
+        0 => account_info,
+    );
+
+    let address = AddressInfo::create(account_info, None)?;
+
+    assign(account_info, &address, &owner)
+}
+
 pub fn process(_program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> ProgramResult {
     match solana_bincode::limited_deserialize::<SystemInstruction>(input, MAX_INPUT_LEN)
         .map_err(|_| ProgramError::InvalidInstructionData)?
@@ -186,6 +197,10 @@ pub fn process(_program_id: &Pubkey, accounts: &[AccountInfo], input: &[u8]) -> 
         } => {
             msg!("Instruction: AllocateWithSeed");
             process_allocate_with_seed(accounts, base, seed, space, owner)
+        }
+        SystemInstruction::Assign { owner } => {
+            msg!("Instruction: Assign");
+            process_assign(accounts, owner)
         }
         /* TODO: Remaining instruction implementations... */
         _ => Err(ProgramError::InvalidInstructionData),

--- a/program/tests/assign.rs
+++ b/program/tests/assign.rs
@@ -1,0 +1,61 @@
+mod setup;
+
+use {
+    mollusk_svm::result::Check, solana_account::Account, solana_program_error::ProgramError,
+    solana_pubkey::Pubkey, solana_system_interface::instruction::assign,
+};
+
+const OWNER: Pubkey = Pubkey::new_from_array([8; 32]);
+
+#[test]
+fn fail_account_not_signer() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    let mut instruction = assign(&pubkey, &OWNER);
+    instruction.accounts[0].is_signer = false;
+
+    mollusk.process_and_validate_instruction(
+        &instruction,
+        &[(pubkey, Account::default())],
+        &[Check::err(ProgramError::MissingRequiredSignature)],
+    );
+}
+
+#[test]
+fn success() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    mollusk.process_and_validate_instruction(
+        &assign(&pubkey, &OWNER),
+        &[(pubkey, Account::default())],
+        &[
+            Check::success(),
+            Check::account(&pubkey).owner(&OWNER).build(),
+        ],
+    );
+}
+
+#[test]
+fn success_already_assigned() {
+    let mollusk = setup::setup();
+
+    let pubkey = Pubkey::new_unique();
+
+    let account = Account {
+        owner: OWNER, // Already assigned
+        ..Account::default()
+    };
+
+    mollusk.process_and_validate_instruction(
+        &assign(&pubkey, &OWNER),
+        &[(pubkey, account)],
+        &[
+            Check::success(),
+            Check::account(&pubkey).owner(&OWNER).build(),
+        ],
+    );
+}


### PR DESCRIPTION
This PR implements the `Assign` instruction processor in the BPF version of the System builtin program.

See #38 for a draft overview of the implemented base processor (no nonce instructions).