### PR TITLE
build: Add 'js' Cargo feature flag for WASM builds

### DIFF
--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -28,8 +28,8 @@ solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-js-sys = "0.3.72"
-wasm-bindgen = "0.2"
+js-sys = { version = "0.3.72", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.89"
@@ -56,6 +56,7 @@ frozen-abi = [
     "solana-pubkey/frozen-abi",
     "solana-pubkey/std"
 ]
+js = ["dep:js-sys", "dep:wasm-bindgen"]
 serde = ["dep:serde", "dep:serde_derive", "solana-pubkey/serde"]
 
 [lib]

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub mod error;
 pub mod instruction;
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "js")]
 mod wasm;
 
 #[cfg(test)]

--- a/interface/src/wasm.rs
+++ b/interface/src/wasm.rs
@@ -1,5 +1,5 @@
 //! `SystemInstruction` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "js")]
 #![allow(non_snake_case)]
 use {
     crate::instruction::{


### PR DESCRIPTION
Previously, the `wasm32` target implicitly assumed a browser environment, which caused issues when building for non-browser WASM environments due to the unconditional inclusion of `wasm-bindgen`.

This commit introduces an explicit 'js' feature flag, making `wasm-bindgen` and `js-sys` conditional dependencies. This allows greater flexibility for different WASM execution environments.

Related to #47