### PR TITLE
Set explicit permissions on publish workflows

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -59,6 +59,9 @@ jobs:
   main:
     needs: set_env
     uses: solana-program/actions/.github/workflows/publish-js.yml@main
+    permissions:
+      contents: write
+      id-token: write
     with:
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}
       target: ${{ needs.set_env.outputs.TARGET }}

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -66,6 +66,9 @@ jobs:
   main:
     needs: set_env
     uses: solana-program/actions/.github/workflows/publish-rust.yml@main
+    permissions:
+      contents: write
+      id-token: write
     with:
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}
       clippy-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}


### PR DESCRIPTION
This PR explicitly sets `contents: write` and `id-token: write` permissions on the `main` job of the publishing caller workflows so they no longer rely on org/enterprise default `GITHUB_TOKEN` permissions, which recently changed and broke the release pipelines.