### PR TITLE
Add clear signing display metadata to the IDL

### DIFF
--- a/idl.json
+++ b/idl.json
@@ -46,8 +46,7 @@
                                     "unit": { "kind": "stringValueNode", "string": "SOL" }
                                 }
                             },
-                            "docs": [],
-                            "display": { "kind": "structFieldDisplayNode", "label": "Lamports per signature" }
+                            "docs": []
                         }
                     ]
                 },
@@ -68,8 +67,7 @@
                         "isSigner": true,
                         "isOptional": false,
                         "docs": [],
-                        "defaultValue": { "kind": "payerValueNode" },
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Payer" }
+                        "defaultValue": { "kind": "payerValueNode" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -77,8 +75,7 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "New account" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -108,7 +105,7 @@
                                 "unit": { "kind": "stringValueNode", "string": "SOL" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Funding amount" },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Funding Amount" },
                         "docs": []
                     },
                     {
@@ -123,7 +120,6 @@
                                 "unit": { "kind": "stringValueNode", "string": "bytes" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
@@ -131,7 +127,7 @@
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner Program" }
                     }
                 ],
                 "byteDeltas": [
@@ -167,8 +163,7 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Account" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -190,7 +185,7 @@
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner Program" }
                     }
                 ],
                 "discriminators": [
@@ -259,8 +254,7 @@
                                 "unit": { "kind": "stringValueNode", "string": "SOL" }
                             }
                         },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Amount" }
+                        "docs": []
                     }
                 ],
                 "discriminators": [
@@ -290,8 +284,7 @@
                         "isSigner": true,
                         "isOptional": false,
                         "docs": [],
-                        "defaultValue": { "kind": "payerValueNode" },
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Payer" }
+                        "defaultValue": { "kind": "payerValueNode" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -299,8 +292,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "New account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -308,8 +300,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": true,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -331,7 +322,7 @@
                         "name": "base",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Base address" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Base Address" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -345,8 +336,7 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Seed" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -362,7 +352,7 @@
                             }
                         },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Funding amount" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Funding Amount" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -376,7 +366,6 @@
                                 "unit": { "kind": "stringValueNode", "string": "bytes" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
@@ -384,7 +373,7 @@
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner Program" }
                     }
                 ],
                 "discriminators": [
@@ -413,8 +402,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -435,8 +423,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce authority" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -480,8 +467,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -524,8 +510,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce authority" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -585,8 +570,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -633,8 +617,7 @@
                         "kind": "instructionArgumentNode",
                         "name": "nonceAuthority",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Nonce authority" }
+                        "docs": []
                     }
                 ],
                 "discriminators": [
@@ -663,8 +646,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -672,8 +654,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce authority" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -694,8 +675,7 @@
                         "kind": "instructionArgumentNode",
                         "name": "newNonceAuthority",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "New nonce authority" }
+                        "docs": []
                     }
                 ],
                 "discriminators": [
@@ -754,7 +734,6 @@
                                 "unit": { "kind": "stringValueNode", "string": "bytes" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     }
                 ],
@@ -793,8 +772,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -816,7 +794,7 @@
                         "name": "base",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Base address" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Base Address" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -830,8 +808,7 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Seed" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -845,7 +822,6 @@
                                 "unit": { "kind": "stringValueNode", "string": "bytes" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
@@ -853,7 +829,7 @@
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner Program" }
                     }
                 ],
                 "discriminators": [
@@ -882,8 +858,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -891,8 +866,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -914,7 +888,7 @@
                         "name": "base",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Base address" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Base Address" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -928,15 +902,14 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Seed" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner Program" }
                     }
                 ],
                 "discriminators": [
@@ -974,8 +947,7 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -1014,8 +986,7 @@
                                 "unit": { "kind": "stringValueNode", "string": "SOL" }
                             }
                         },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Amount" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -1029,15 +1000,13 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "From seed" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "fromOwner",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "From owner" }
+                        "docs": []
                     }
                 ],
                 "discriminators": [
@@ -1066,8 +1035,7 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
+                        "docs": []
                     }
                 ],
                 "arguments": [
@@ -1111,8 +1079,7 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": [],
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "New account" }
+                        "docs": []
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -1121,8 +1088,7 @@
                         "isSigner": true,
                         "isOptional": true,
                         "docs": [],
-                        "defaultValue": { "kind": "payerValueNode" },
-                        "display": { "kind": "instructionAccountDisplayNode", "label": "Payer" }
+                        "defaultValue": { "kind": "payerValueNode" }
                     }
                 ],
                 "arguments": [
@@ -1152,7 +1118,7 @@
                                 "unit": { "kind": "stringValueNode", "string": "SOL" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Funding amount" },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Funding Amount" },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 0 },
                         "defaultValueStrategy": "optional"
@@ -1169,7 +1135,6 @@
                                 "unit": { "kind": "stringValueNode", "string": "bytes" }
                             }
                         },
-                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
@@ -1177,7 +1142,7 @@
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
                         "docs": [],
-                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner Program" }
                     }
                 ],
                 "byteDeltas": [

--- a/idl.json
+++ b/idl.json
@@ -39,9 +39,15 @@
                             "type": {
                                 "kind": "numberTypeNode",
                                 "format": "u64",
-                                "endian": "le"
+                                "endian": "le",
+                                "display": {
+                                    "kind": "amountNumberDisplayNode",
+                                    "decimals": { "kind": "numberValueNode", "number": 9 },
+                                    "unit": { "kind": "stringValueNode", "string": "SOL" }
+                                }
                             },
-                            "docs": []
+                            "docs": [],
+                            "display": { "kind": "structFieldDisplayNode", "label": "Lamports per signature" }
                         }
                     ]
                 },
@@ -62,7 +68,8 @@
                         "isSigner": true,
                         "isOptional": false,
                         "docs": [],
-                        "defaultValue": { "kind": "payerValueNode" }
+                        "defaultValue": { "kind": "payerValueNode" },
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Payer" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -70,7 +77,8 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "New account" }
                     }
                 ],
                 "arguments": [
@@ -84,7 +92,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 0 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -92,8 +101,14 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "decimals": { "kind": "numberValueNode", "number": 9 },
+                                "unit": { "kind": "stringValueNode", "string": "SOL" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Funding amount" },
                         "docs": []
                     },
                     {
@@ -102,15 +117,21 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": { "kind": "stringValueNode", "string": "bytes" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
                     }
                 ],
                 "byteDeltas": [
@@ -130,7 +151,12 @@
                 "name": "createAccount",
                 "idlName": "CreateAccount",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Create account",
+                    "interpolatedIntent": "Create account ${accounts.newAccount} with ${data.lamports}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -141,7 +167,8 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Account" }
                     }
                 ],
                 "arguments": [
@@ -155,13 +182,15 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 1 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
                     }
                 ],
                 "discriminators": [
@@ -174,7 +203,12 @@
                 "name": "assign",
                 "idlName": "Assign",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Assign account",
+                    "interpolatedIntent": "Assign ${accounts.account} to program ${data.programAddress}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -185,7 +219,8 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "From" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -193,7 +228,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "To" }
                     }
                 ],
                 "arguments": [
@@ -207,7 +243,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 2 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -215,9 +252,15 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "decimals": { "kind": "numberValueNode", "number": 9 },
+                                "unit": { "kind": "stringValueNode", "string": "SOL" }
+                            }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Amount" }
                     }
                 ],
                 "discriminators": [
@@ -230,7 +273,12 @@
                 "name": "transferSol",
                 "idlName": "TransferSol",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer SOL",
+                    "interpolatedIntent": "Transfer ${data.amount} from ${accounts.source} to ${accounts.destination}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -242,7 +290,8 @@
                         "isSigner": true,
                         "isOptional": false,
                         "docs": [],
-                        "defaultValue": { "kind": "payerValueNode" }
+                        "defaultValue": { "kind": "payerValueNode" },
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Payer" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -250,7 +299,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "New account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -258,7 +308,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": true,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
                     }
                 ],
                 "arguments": [
@@ -272,13 +323,15 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 3 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "base",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Base address" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -292,7 +345,8 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Seed" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -300,9 +354,15 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "decimals": { "kind": "numberValueNode", "number": 9 },
+                                "unit": { "kind": "stringValueNode", "string": "SOL" }
+                            }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Funding amount" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -310,15 +370,21 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": { "kind": "stringValueNode", "string": "bytes" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
                     }
                 ],
                 "discriminators": [
@@ -331,7 +397,12 @@
                 "name": "createAccountWithSeed",
                 "idlName": "CreateAccountWithSeed",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Create account with seed",
+                    "interpolatedIntent": "Create account ${accounts.newAccount} with ${data.amount}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -342,7 +413,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -354,7 +426,8 @@
                         "defaultValue": {
                             "kind": "publicKeyValueNode",
                             "publicKey": "SysvarRecentB1ockHashes11111111111111111111"
-                        }
+                        },
+                        "display": { "kind": "instructionAccountDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -362,7 +435,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce authority" }
                     }
                 ],
                 "arguments": [
@@ -376,7 +450,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 4 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     }
                 ],
                 "discriminators": [
@@ -389,7 +464,12 @@
                 "name": "advanceNonceAccount",
                 "idlName": "AdvanceNonceAccount",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Advance nonce account",
+                    "interpolatedIntent": "Advance nonce account ${accounts.nonceAccount}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -400,7 +480,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -408,7 +489,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Recipient" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -420,7 +502,8 @@
                         "defaultValue": {
                             "kind": "publicKeyValueNode",
                             "publicKey": "SysvarRecentB1ockHashes11111111111111111111"
-                        }
+                        },
+                        "display": { "kind": "instructionAccountDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -432,7 +515,8 @@
                         "defaultValue": {
                             "kind": "publicKeyValueNode",
                             "publicKey": "SysvarRent111111111111111111111111111111111"
-                        }
+                        },
+                        "display": { "kind": "instructionAccountDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -440,7 +524,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce authority" }
                     }
                 ],
                 "arguments": [
@@ -454,7 +539,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 5 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -462,9 +548,15 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "decimals": { "kind": "numberValueNode", "number": 9 },
+                                "unit": { "kind": "stringValueNode", "string": "SOL" }
+                            }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Amount" }
                     }
                 ],
                 "discriminators": [
@@ -477,7 +569,12 @@
                 "name": "withdrawNonceAccount",
                 "idlName": "WithdrawNonceAccount",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Withdraw from nonce account",
+                    "interpolatedIntent": "Withdraw ${data.withdrawAmount} from ${accounts.nonceAccount} to ${accounts.recipientAccount}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -488,7 +585,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -500,7 +598,8 @@
                         "defaultValue": {
                             "kind": "publicKeyValueNode",
                             "publicKey": "SysvarRecentB1ockHashes11111111111111111111"
-                        }
+                        },
+                        "display": { "kind": "instructionAccountDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -512,7 +611,8 @@
                         "defaultValue": {
                             "kind": "publicKeyValueNode",
                             "publicKey": "SysvarRent111111111111111111111111111111111"
-                        }
+                        },
+                        "display": { "kind": "instructionAccountDisplayNode", "skip": "always" }
                     }
                 ],
                 "arguments": [
@@ -526,13 +626,15 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 6 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "nonceAuthority",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Nonce authority" }
                     }
                 ],
                 "discriminators": [
@@ -545,7 +647,12 @@
                 "name": "initializeNonceAccount",
                 "idlName": "InitializeNonceAccount",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Initialize nonce account",
+                    "interpolatedIntent": "Initialize nonce account ${accounts.nonceAccount} with authority ${data.nonceAuthority}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -556,7 +663,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -564,7 +672,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce authority" }
                     }
                 ],
                 "arguments": [
@@ -578,13 +687,15 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 7 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "newNonceAuthority",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "New nonce authority" }
                     }
                 ],
                 "discriminators": [
@@ -597,7 +708,12 @@
                 "name": "authorizeNonceAccount",
                 "idlName": "AuthorizeNonceAccount",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Authorize nonce account",
+                    "interpolatedIntent": "Set the authority of nonce account ${accounts.nonceAccount} to ${data.newNonceAuthority}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -608,7 +724,8 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Account" }
                     }
                 ],
                 "arguments": [
@@ -622,7 +739,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 8 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -630,8 +748,13 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": { "kind": "stringValueNode", "string": "bytes" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     }
                 ],
@@ -645,7 +768,12 @@
                 "name": "allocate",
                 "idlName": "Allocate",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Allocate space",
+                    "interpolatedIntent": "Allocate ${data.space} for ${accounts.newAccount}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -656,7 +784,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -664,7 +793,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
                     }
                 ],
                 "arguments": [
@@ -678,13 +808,15 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 9 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "base",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Base address" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -698,7 +830,8 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Seed" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -706,15 +839,21 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": { "kind": "stringValueNode", "string": "bytes" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
                     }
                 ],
                 "discriminators": [
@@ -727,7 +866,12 @@
                 "name": "allocateWithSeed",
                 "idlName": "AllocateWithSeed",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Allocate space with seed",
+                    "interpolatedIntent": "Allocate ${data.space} for ${accounts.newAccount}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -738,7 +882,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -746,7 +891,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
                     }
                 ],
                 "arguments": [
@@ -760,13 +906,15 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 10 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "base",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Base address" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -780,13 +928,15 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Seed" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
                     }
                 ],
                 "discriminators": [
@@ -799,7 +949,12 @@
                 "name": "assignWithSeed",
                 "idlName": "AssignWithSeed",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Assign account with seed",
+                    "interpolatedIntent": "Assign ${accounts.account} to program ${data.programAddress}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -810,7 +965,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "From" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -818,7 +974,8 @@
                         "isWritable": false,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Base account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -826,7 +983,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "To" }
                     }
                 ],
                 "arguments": [
@@ -840,7 +998,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 11 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -848,9 +1007,15 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "decimals": { "kind": "numberValueNode", "number": 9 },
+                                "unit": { "kind": "stringValueNode", "string": "SOL" }
+                            }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Amount" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -864,13 +1029,15 @@
                                 "endian": "le"
                             }
                         },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "From seed" }
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "fromOwner",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "From owner" }
                     }
                 ],
                 "discriminators": [
@@ -883,7 +1050,12 @@
                 "name": "transferSolWithSeed",
                 "idlName": "TransferSolWithSeed",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Transfer SOL with seed",
+                    "interpolatedIntent": "Transfer ${data.amount} from ${accounts.source} to ${accounts.destination}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -894,7 +1066,8 @@
                         "isWritable": true,
                         "isSigner": false,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Nonce account" }
                     }
                 ],
                 "arguments": [
@@ -908,7 +1081,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 12 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     }
                 ],
                 "discriminators": [
@@ -921,7 +1095,12 @@
                 "name": "upgradeNonceAccount",
                 "idlName": "UpgradeNonceAccount",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Upgrade nonce account",
+                    "interpolatedIntent": "Upgrade nonce account ${accounts.nonceAccount}"
+                }
             },
             {
                 "kind": "instructionNode",
@@ -932,7 +1111,8 @@
                         "isWritable": true,
                         "isSigner": true,
                         "isOptional": false,
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "New account" }
                     },
                     {
                         "kind": "instructionAccountNode",
@@ -941,7 +1121,8 @@
                         "isSigner": true,
                         "isOptional": true,
                         "docs": [],
-                        "defaultValue": { "kind": "payerValueNode" }
+                        "defaultValue": { "kind": "payerValueNode" },
+                        "display": { "kind": "instructionAccountDisplayNode", "label": "Payer" }
                     }
                 ],
                 "arguments": [
@@ -955,7 +1136,8 @@
                         },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 13 },
-                        "defaultValueStrategy": "omitted"
+                        "defaultValueStrategy": "omitted",
+                        "display": { "kind": "structFieldDisplayNode", "skip": "always" }
                     },
                     {
                         "kind": "instructionArgumentNode",
@@ -963,8 +1145,14 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "decimals": { "kind": "numberValueNode", "number": 9 },
+                                "unit": { "kind": "stringValueNode", "string": "SOL" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Funding amount" },
                         "docs": [],
                         "defaultValue": { "kind": "numberValueNode", "number": 0 },
                         "defaultValueStrategy": "optional"
@@ -975,15 +1163,21 @@
                         "type": {
                             "kind": "numberTypeNode",
                             "format": "u64",
-                            "endian": "le"
+                            "endian": "le",
+                            "display": {
+                                "kind": "amountNumberDisplayNode",
+                                "unit": { "kind": "stringValueNode", "string": "bytes" }
+                            }
                         },
+                        "display": { "kind": "structFieldDisplayNode", "label": "Space" },
                         "docs": []
                     },
                     {
                         "kind": "instructionArgumentNode",
                         "name": "programAddress",
                         "type": { "kind": "publicKeyTypeNode" },
-                        "docs": []
+                        "docs": [],
+                        "display": { "kind": "structFieldDisplayNode", "label": "Owner program" }
                     }
                 ],
                 "byteDeltas": [
@@ -1003,7 +1197,12 @@
                 "name": "createAccountAllowPrefund",
                 "idlName": "CreateAccountAllowPrefund",
                 "docs": [],
-                "optionalAccountStrategy": "omitted"
+                "optionalAccountStrategy": "omitted",
+                "display": {
+                    "kind": "instructionDisplayNode",
+                    "intent": "Create account",
+                    "interpolatedIntent": "Create account ${accounts.newAccount} with ${data.lamports}"
+                }
             }
         ],
         "definedTypes": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {
         "@codama/renderers-js": "^2.3.0",
         "@codama/renderers-rust": "^3.1.0",
-        "codama": "^1.8.0",
+        "codama": "^1.10.0",
         "typescript": "^5.9.3"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,16 +15,20 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       codama:
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
 
 packages:
 
-  '@codama/cli@1.5.3':
-    resolution: {integrity: sha512-RgLwZ24sGkPDwaH3DovOY3e1VXPnPwDBXojYXyOzPmEjQ23yTKacrLa3Zlt/XjMsXv9cLOym5OheC+gG6GxIpg==}
+  '@codama/cli@1.6.0':
+    resolution: {integrity: sha512-68fam0kzWsKp2ip/LZn3kDyFjWcbzHExCuDgEHGTX8C0gSscMch/c4EgtTq7NsWKc1cse0GMC5WIxCFumroTyQ==}
+    hasBin: true
+
+  '@codama/errors@1.10.0':
+    resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
   '@codama/errors@1.5.0':
@@ -42,6 +46,9 @@ packages:
   '@codama/fragments@0.1.1':
     resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
 
+  '@codama/node-types@1.10.0':
+    resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
+
   '@codama/node-types@1.5.0':
     resolution: {integrity: sha512-Ebz2vOUukmNaFXWdkni1ZihXkAIUnPYtqIMXYxKXOxjMP+TGz2q0lGtRo7sqw1pc2ksFBIkfBp5pZsl5p6gwXA==}
 
@@ -50,6 +57,9 @@ packages:
 
   '@codama/node-types@1.8.0':
     resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
+
+  '@codama/nodes@1.10.0':
+    resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
   '@codama/nodes@1.5.0':
     resolution: {integrity: sha512-yg+xmorWiMNjS3n19CGIt/FZ/ZCuDIu+HEY45bq6gHu1MN3RtJZY+Q3v0ErnBPA60D8mNWkvkKoeSZXfzcAvfw==}
@@ -74,8 +84,11 @@ packages:
     resolution: {integrity: sha512-E/GSUCuiIpFj+ij3NbduH/h3sNDo39Bq14vj2atxdbbrPmu4clWvIEjXtbmP03qhudH73TxbYO8dWg/NwRi18A==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/validators@1.8.0':
-    resolution: {integrity: sha512-gDmS85DwWmT41+PWTlbBrkSopGKW4UPhEcX+SLb2fF/uXMpJQXcgLE8BE9Fr7/DO+M9yFtGOVrnfDSCwepORGg==}
+  '@codama/validators@1.10.0':
+    resolution: {integrity: sha512-5WH1IHmyVVG/9QThZsrVM2ROv5w3yLF/8+4HK/kr8uw0ZXnIBGidnmyrxr1P8V+X6DgZqKJaX46V30dSs/NOTQ==}
+
+  '@codama/visitors-core@1.10.0':
+    resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
   '@codama/visitors-core@1.5.0':
     resolution: {integrity: sha512-3PIAlBX0a06hIxzyPtQMfQcqWGFBgfbwysSwcXBbvHUYbemwhD6xwlBKJuqTwm9DyFj3faStp5fpvcp03Rjxtw==}
@@ -86,8 +99,8 @@ packages:
   '@codama/visitors-core@1.8.0':
     resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
 
-  '@codama/visitors@1.8.0':
-    resolution: {integrity: sha512-vQ863YkHBdLWZeaiPKisiRe0bbuBEBe9xDWVcLCCLRsmKCQuS+GB4bKxIwrlTr9cxCOGyQLkI7B/yAqyYEdbmw==}
+  '@codama/visitors@1.10.0':
+    resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -154,8 +167,8 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  codama@1.8.0:
-    resolution: {integrity: sha512-P1hctEUpZfgjm3xfosrD4xo/SVnp17ONuGDDtBmkyOaJBBL2JkYXjomZF9xOQqhvlfgcgqRKNB96Lcs4MG/fLQ==}
+  codama@1.10.0:
+    resolution: {integrity: sha512-fH1wz1P6bbPOWNM23Sk4VzRSpqxRW1CpXNiWQY23vHT2tno/K1/JtaaUc7DS5ddl5rGFKtq9R2UFsegR96IxRQ==}
     hasBin: true
 
   commander@14.0.3:
@@ -278,14 +291,20 @@ packages:
 
 snapshots:
 
-  '@codama/cli@1.5.3':
+  '@codama/cli@1.6.0':
     dependencies:
-      '@codama/nodes': 1.8.0
-      '@codama/visitors': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors': 1.10.0
+      '@codama/visitors-core': 1.10.0
       commander: 14.0.3
       picocolors: 1.1.1
       prompts: 2.4.2
+
+  '@codama/errors@1.10.0':
+    dependencies:
+      '@codama/node-types': 1.10.0
+      commander: 14.0.3
+      picocolors: 1.1.1
 
   '@codama/errors@1.5.0':
     dependencies:
@@ -309,11 +328,18 @@ snapshots:
     dependencies:
       '@codama/errors': 1.8.0
 
+  '@codama/node-types@1.10.0': {}
+
   '@codama/node-types@1.5.0': {}
 
   '@codama/node-types@1.6.0': {}
 
   '@codama/node-types@1.8.0': {}
+
+  '@codama/nodes@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/node-types': 1.10.0
 
   '@codama/nodes@1.5.0':
     dependencies:
@@ -371,11 +397,17 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/validators@1.8.0':
+  '@codama/validators@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
+
+  '@codama/visitors-core@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      json-stable-stringify: 1.3.0
 
   '@codama/visitors-core@1.5.0':
     dependencies:
@@ -395,11 +427,11 @@ snapshots:
       '@codama/nodes': 1.8.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.8.0':
+  '@codama/visitors@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
   '@iarna/toml@2.2.5': {}
 
@@ -455,13 +487,13 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  codama@1.8.0:
+  codama@1.10.0:
     dependencies:
-      '@codama/cli': 1.5.3
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/validators': 1.8.0
-      '@codama/visitors': 1.8.0
+      '@codama/cli': 1.6.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/validators': 1.10.0
+      '@codama/visitors': 1.10.0
 
   commander@14.0.3: {}
 


### PR DESCRIPTION
This PR enriches the Codama IDL with display metadata for clear signing, per [sRFC 39](https://github.com/solana-foundation/SRFCs/discussions/4), and bumps `codama` to `^1.10.0` (the display node types shipped in 1.9). All 14 instructions gain intents and interpolated intents; accounts and arguments gain labels; lamport amounts render as SOL (`decimals: 9`), sizes as `bytes`; discriminators and fixed sysvar accounts (rent, recent blockhashes) are hidden from the fallback list. The `nonce` account's `lamportsPerSignature` field also renders as SOL.

Sample renders via `@codama/dynamic-instructions`:

```
Transfer 1.5 SOL from 3Wnd5…PxJX to 9WzDX…AWWM
Create account Fg6Pa…sLnS with 0.00203928 SOL
Withdraw 0.5 SOL from DRpbC…21hy to 9WzDX…AWWM
```

Clients were regenerated and are unaffected: renderers pass display metadata through untouched.